### PR TITLE
Step4: 다대다 관계 테이블을 사용하여 사용자가 동일한 특강에 대해서는 신청을 성공하지 못 하도록 하는 기능 추가

### DIFF
--- a/src/main/java/hhplus/ch2/architecture/lecture/adapter/out/persistence/UserLectureRepositoryImpl.java
+++ b/src/main/java/hhplus/ch2/architecture/lecture/adapter/out/persistence/UserLectureRepositoryImpl.java
@@ -1,7 +1,6 @@
 package hhplus.ch2.architecture.lecture.adapter.out.persistence;
 
 import hhplus.ch2.architecture.lecture.adapter.out.persistence.jpa.UserLectureJpaRepository;
-import hhplus.ch2.architecture.lecture.domain.entity.Lecture;
 import hhplus.ch2.architecture.lecture.domain.entity.UserLecture;
 import hhplus.ch2.architecture.lecture.application.port.out.UserLectureRepository;
 import hhplus.ch2.architecture.lecture.adapter.out.persistence.entity.UserLectureEntity;
@@ -19,5 +18,10 @@ public class UserLectureRepositoryImpl implements UserLectureRepository {
     @Override
     public UserLecture save(UserLecture userLecture) {
         return userLectureJpaRepository.save(UserLectureEntity.fromDomain(userLecture)).toDomain();
+    }
+
+    @Override
+    public boolean existsByUserLecture(UserLecture userLecture) {
+        return userLectureJpaRepository.existsByUserIdAndLectureItemId(userLecture.getUser().getId(), userLecture.getLectureItem().getId());
     }
 }

--- a/src/main/java/hhplus/ch2/architecture/lecture/adapter/out/persistence/jpa/UserLectureJpaRepository.java
+++ b/src/main/java/hhplus/ch2/architecture/lecture/adapter/out/persistence/jpa/UserLectureJpaRepository.java
@@ -3,7 +3,15 @@ package hhplus.ch2.architecture.lecture.adapter.out.persistence.jpa;
 import hhplus.ch2.architecture.lecture.adapter.out.persistence.entity.UserLectureEntity;
 import hhplus.ch2.architecture.lecture.adapter.out.persistence.entity.UserLectureEntityId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserLectureJpaRepository extends JpaRepository<UserLectureEntity, UserLectureEntityId> {
 
+    @Query("""
+            SELECT CASE WHEN COUNT(ul) > 0 THEN TRUE ELSE FALSE END
+            FROM UserLectureEntity ul
+            WHERE ul.userEntity.id = :userId
+            AND ul.lectureItemEntity.id = :lectureItemId
+            """)
+    boolean existsByUserIdAndLectureItemId(Long userId, Long lectureItemId);
 }

--- a/src/main/java/hhplus/ch2/architecture/lecture/application/RegisterLectureService.java
+++ b/src/main/java/hhplus/ch2/architecture/lecture/application/RegisterLectureService.java
@@ -7,6 +7,7 @@ import hhplus.ch2.architecture.lecture.application.port.out.LectureItemRepositor
 import hhplus.ch2.architecture.lecture.application.port.out.UserLectureRepository;
 import hhplus.ch2.architecture.lecture.application.port.out.UserRepository;
 import hhplus.ch2.architecture.lecture.application.response.LectureRegistrationResult;
+import hhplus.ch2.architecture.lecture.common.exception.AlreadyRegisteredLectureException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchLectureItemException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchLectureItemInventoryException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchUserException;
@@ -40,10 +41,9 @@ public class RegisterLectureService implements RegisterLectureUseCase {
         UserLecture userLecture = lectureItem.registerUser(lectureItemInventory.getLeftSeat(), user);
         lectureItemInventory = lectureItemInventoryRepository.decreaseLeftSeatById(lectureItemInventory);
 
-        // TODO: 2024-09-29 STEP 4 과제
-//        if (userLectureRepository.existsByUserAndLecture(user, lecture)) {
-//            throw new IllegalArgumentException("Already registered");
-//        }
+        if (userLectureRepository.existsByUserLecture(userLecture)) {
+            throw new AlreadyRegisteredLectureException(lectureItemId);
+        }
         userLectureRepository.save(userLecture);
         return new LectureRegistrationResult(lectureItemId, userId);
     }

--- a/src/main/java/hhplus/ch2/architecture/lecture/application/port/out/UserLectureRepository.java
+++ b/src/main/java/hhplus/ch2/architecture/lecture/application/port/out/UserLectureRepository.java
@@ -5,4 +5,6 @@ import hhplus.ch2.architecture.lecture.domain.entity.UserLecture;
 public interface UserLectureRepository {
 
     UserLecture save(UserLecture userLecture);
+
+    boolean existsByUserLecture(UserLecture userLecture);
 }

--- a/src/main/java/hhplus/ch2/architecture/lecture/common/exception/AlreadyRegisteredLectureException.java
+++ b/src/main/java/hhplus/ch2/architecture/lecture/common/exception/AlreadyRegisteredLectureException.java
@@ -1,0 +1,11 @@
+package hhplus.ch2.architecture.lecture.common.exception;
+
+import hhplus.ch2.architecture.lecture.adapter.in.web.model.common.ApiCode;
+import hhplus.ch2.architecture.lecture.adapter.in.web.model.common.ErrorResponse;
+
+public class AlreadyRegisteredLectureException extends ApiException {
+
+    public AlreadyRegisteredLectureException(Long lectureItemId) {
+        super(ErrorResponse.error(ApiCode.POLICY_VIOLATION, null, "Lecture item %d is already registered".formatted(lectureItemId)));
+    }
+}

--- a/src/test/java/hhplus/ch2/architecture/integration/adapter/out/persistence/jpa/UserLectureRepositoryImplTest.java
+++ b/src/test/java/hhplus/ch2/architecture/integration/adapter/out/persistence/jpa/UserLectureRepositoryImplTest.java
@@ -66,6 +66,39 @@ public class UserLectureRepositoryImplTest extends DataJpaTestEnvironment {
         assertThat(saveUserLectureEntity.getLectureItemEntity().getId()).isEqualTo(lectureItemEntity.getId());
     }
 
+    @DisplayName("사용자가 강의를 이미 신청했는지 여부를 알 수 있다.")
+    @Test
+    void existsByUserIdAndLectureItemId() {
+        // given
+        InstructorEntity instructorEntity = buildInstructorEntity("강사1");
+        instructorJpaRepository.save(instructorEntity);
+
+        LectureEntity lectureEntity = buildLectureEntity("강의1", instructorEntity);
+        lectureJpaRepository.save(lectureEntity);
+
+        LectureItemEntity lectureItemEntity = buildLectureItemEntity(lectureEntity, LocalDateTime.now().with(DayOfWeek.SATURDAY), 10L);
+        lectureItemJpaRepository.save(lectureItemEntity);
+
+        LectureItemInventoryEntity lectureItemInventoryEntity = buildLectureItemInventoryEntity(lectureItemEntity, 10L);
+        lectureItemInventoryJpaRepository.save(lectureItemInventoryEntity);
+
+        UserEntity userEntity = buildUserEntity("사용자1");
+        userJpaRepository.save(userEntity);
+
+        UserLectureEntity userLectureEntity = UserLectureEntity.builder()
+                .userEntity(userEntity)
+                .lectureItemEntity(lectureItemEntity)
+                .createdDateTime(LocalDateTime.now())
+                .build();
+        sut.save(userLectureEntity);
+
+        // when
+        boolean exists = sut.existsByUserIdAndLectureItemId(userEntity.getId(), lectureItemEntity.getId());
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
     private InstructorEntity buildInstructorEntity(String name) {
         return InstructorEntity.instructorBuilder()
                 .name(name)

--- a/src/test/java/hhplus/ch2/architecture/unit/application/RegisterLectureServiceTest.java
+++ b/src/test/java/hhplus/ch2/architecture/unit/application/RegisterLectureServiceTest.java
@@ -6,10 +6,12 @@ import hhplus.ch2.architecture.lecture.application.port.out.LectureItemInventory
 import hhplus.ch2.architecture.lecture.application.port.out.LectureItemRepository;
 import hhplus.ch2.architecture.lecture.application.port.out.UserLectureRepository;
 import hhplus.ch2.architecture.lecture.application.port.out.UserRepository;
+import hhplus.ch2.architecture.lecture.common.exception.AlreadyRegisteredLectureException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchLectureItemException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchLectureItemInventoryException;
 import hhplus.ch2.architecture.lecture.common.exception.NoSuchUserException;
 import hhplus.ch2.architecture.lecture.domain.entity.LectureItem;
+import hhplus.ch2.architecture.lecture.domain.entity.LectureItemInventory;
 import hhplus.ch2.architecture.lecture.domain.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -91,5 +93,28 @@ public class RegisterLectureServiceTest {
         assertThatThrownBy(() -> sut.registerLecture(command))
                 .isInstanceOf(NoSuchLectureItemInventoryException.class)
                 .hasMessage("No such lecture item inventory: 1");
+    }
+
+    @DisplayName("사용자는 이미 신청한 강의를 다시 신청할 수 없다.")
+    @Test
+    void registerLectureWithAlreadyRegisteredLecture() {
+        // mock
+        User user = User.builder().build();
+        LectureItem lectureItem = LectureItem.builder().build();
+        LectureItemInventory lectureItemInventory = LectureItemInventory.builder().leftSeat(1L).build();
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(lectureItemRepository.findById(anyLong())).thenReturn(Optional.of(lectureItem));
+        when(lectureItemInventoryRepository.findByLectureItem(any())).thenReturn(Optional.of(lectureItemInventory));
+        when(userLectureRepository.existsByUserLecture(any())).thenReturn(true);
+
+        // given
+        RegisterLectureCommand command = new RegisterLectureCommand(1L, 1L);
+
+        // when
+        // then
+        assertThatThrownBy(() -> sut.registerLecture(command))
+                .isInstanceOf(AlreadyRegisteredLectureException.class)
+                .hasMessage("Lecture item %d is already registered".formatted(1L));
     }
 }


### PR DESCRIPTION
### 변경사항
- 기존의 다대다 관계 테이블인 user_lectures 를 사용하여, [이미 어떠한 사용자가 어떠한 특강을 신청했는지에 대한 레코드가 있는지를 조회](https://github.com/psam1017/hhplus-ch2-architecture/pull/5/files#diff-a14fc0ea1e4b7b5046037910611151c7bb510c39afee3c4db1728b27ddbefb9bR10-R16)하고, [만약 있다면 예외를 던지도록](https://github.com/psam1017/hhplus-ch2-architecture/pull/5/files#diff-a0677efe424732070254d87e88cbad01c9b40237478dc877e74123a15f9b5de6R44-R46) 했습니다.
- 기능 추가로 추가된 메서드 및 기능에 대한 단위 테스트를 작성했습니다.
- 한 사용자가 동일한 특강에 대해 5번 요청했을 때 딱 1번만 성공하고 나머지 4번은 실패하는지를 검증하는 [통합 테스트](https://github.com/psam1017/hhplus-ch2-architecture/pull/5/files#diff-314da45cec9417686b3e16abdac777b7ad143429e78bfeea1db1fdc4e645aa83R166)를 작성했습니다.

### 테스트 결과
- 언급한 단위 테스트 및 통합 테스트를 통과했습니다.